### PR TITLE
Improve the main core color parsing

### DIFF
--- a/Main/15_Colors.php
+++ b/Main/15_Colors.php
@@ -529,6 +529,13 @@ class Colors_Core extends BasePassiveModule
         foreach ($this->color_tags as $tag => $font) {
             $text = str_ireplace($tag, $font, $text);
         }
+        foreach ($this -> color_tags as $tag => $font)
+        {
+            if (preg_match("/".$tag."[^#]+##end##/i", $text)) {
+                $text = str_ireplace($tag, $font, $text);
+            }
+        }
+        $text = str_ireplace("##end##", "</font>", $text);	    
         return $text;
     }
 


### PR DESCRIPTION
In some specific cases typically like sending sole triggered words like colors (e.g. "pink" which can be used during a pandemonium raid) or sides (e.g. "omni" or "clan" which can be answered on specific questions) the resulting color parsing would become partially or totally broken. The proposed fix doesn't prevent all possible entries to break it but at least ensures the parser will correctly search for fully formatted expressions including font ending. This should cover most human natural use of the chat if not all.