### PR TITLE
Improve the core color parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.gitignore
+
 *.org
 Conf/*.conf
 Conf/*.ini

--- a/Conf/Bot.conf.dist
+++ b/Conf/Bot.conf.dist
@@ -6,7 +6,7 @@
   $ao_username = "";               // Account username
   $ao_password = "";               // Account password (optional, will request on running of Bot if not entered here)
   $bot_name = "";                  // Name of the bot-character
-  $dimension = "";                 // The name of the server you play on, or (1, 2 or 3 for AO)
+  $dimension = "";                 // The name of the server you play on, or (0, 5 or 6 for AO)
   $guild = "";                     // Name of the guild running the bot (AOC only)
 
 /*

--- a/Conf/ServerList.php
+++ b/Conf/ServerList.php
@@ -1,29 +1,11 @@
 <?php
 // AO
-$server_list['Ao']['Testlive'] = array(
-    'server' => 'chat.dt.funcom.com',
-    'port' => 7109
-);
-$server_list['Ao']['Atlantean'] = array(
-    'server' => 'chat.d1.funcom.com',
-    'port' => 7101
-);
-$server_list['Ao']['Rimor'] = array(
-    'server' => 'chat.d2.funcom.com',
-    'port' => 7102
-);
-$server_list['Ao']['Die neue welt'] = array(
-    'server' => 'chat.d3.funcom.com',
-    'port' => 7103
-);
-
-
+$server_list['Ao']['Testlive'] = array('server' => 'chat.dt.funcom.com', 'port' => 7109);
 $server_list['Ao']['Rubi-Ka'] = array('server' => 'chat.d1.funcom.com', 'port' => 7105);
-
+$server_list['Ao']['Rubi-Ka-2019'] = array('server' => 'chat.d1.funcom.com', 'port' => 7106);
+$server_list['Ao']['0'] = $server_list['Ao']['Testlive'];
 $server_list['Ao']['5'] = $server_list['Ao']['Rubi-Ka'];
-$server_list['Ao']['5'] = $server_list['Ao']['Rubi-Ka'];
-$server_list['Ao']['5'] = $server_list['Ao']['Rubi-Ka'];
-$server_list['Ao']['5'] = $server_list['Ao']['Rubi-Ka'];
+$server_list['Ao']['6'] = $server_list['Ao']['Rubi-Ka-2019'];
 
 // AOC
 $server_list['Aoc']['EU'] = array(

--- a/Main/15_Colors.php
+++ b/Main/15_Colors.php
@@ -526,9 +526,13 @@ class Colors_Core extends BasePassiveModule
             return $text;
         }
         // Go ahead and replace all tags
-        foreach ($this->color_tags as $tag => $font) {
-            $text = str_ireplace($tag, $font, $text);
+        foreach ($this -> color_tags as $tag => $font)
+        {
+            if (preg_match("/".$tag."[^#]+##end##/i", $text)) {
+                $text = str_ireplace($tag, $font, $text);
+            }
         }
+        $text = str_ireplace("##end##", "</font>", $text);
         return $text;
     }
 

--- a/Main/15_Colors.php
+++ b/Main/15_Colors.php
@@ -525,28 +525,25 @@ class Colors_Core extends BasePassiveModule
         if (strpos($text, "##") === false) {
             return $text;
         }
-        // Go ahead and replace all tags
-		$maxpass = 3;
-		$stop = "##end##";
-		$trig = "[^#]+";
-		for($i=1;$i<$maxpass+1;$i++) {
-			foreach ($this -> color_tags as $tag => $font)
-			{
-				if ($tag != $stop) {
-					if (preg_match("/(".$tag.$trig.$stop.")/i", $text, $matches, PREG_OFFSET_CAPTURE))
-					{
-						$prev = substr($text, 0, $matches[1][1]);
-						$repl = str_ireplace($tag, $font, $matches[1][0]);
-						$repl = preg_replace("/".$stop."/", "</font>", $repl, 1);
-						$post = substr($text, $matches[1][1] + strlen($matches[1][0]));
-						$text = $prev.$repl.$post;
-					}			
+	// Go ahead and replace all tags
+	$maxpass = 3; // Increase for more sublevels only if needed
+	$stop = "##end##";
+	$trig = "(?:(?!#{2}).)+";
+	for($i=1;$i<$maxpass+1;$i++) {
+		foreach ($this -> color_tags as $tag => $font) {
+			if ($tag != $stop) {
+				while (preg_match("/(".$tag.$trig.$stop.")/i", $text, $match, PREG_OFFSET_CAPTURE)) {
+					  $prev = substr($text, 0, $match[1][1]);
+					  $repl = preg_replace("/".$tag."/i", $font, $match[1][0], 1);
+					  $repl = preg_replace("/".$stop."/i", "</font>", $repl, 1);
+					  $post = substr($text, $match[1][1] + strlen($match[1][0]));
+					  $text = $prev.$repl.$post;
 				}
 			}
-			$trig = "(?:.*)";
 		}
-	$text = str_ireplace("##end##", "</font>", $text);
-        return $text;
+	}
+	$text = preg_replace("/##[^#]+##/i", "", $text);
+	return $text;
     }
 
 

--- a/Main/15_Colors.php
+++ b/Main/15_Colors.php
@@ -526,17 +526,26 @@ class Colors_Core extends BasePassiveModule
             return $text;
         }
         // Go ahead and replace all tags
-        foreach ($this -> color_tags as $tag => $font)
-        {
-            if (preg_match("/".$tag."[^#]+##end##/i", $text)) {
-                $text = str_ireplace($tag, $font, $text);
-            }
-        }
-        $text = str_ireplace("##end##", "</font>", $text);
-	foreach ($this -> color_tags as $tag => $font)
-	{
-		$text = str_ireplace($tag, $font, $text);
-	}	    
+		$maxpass = 3;
+		$stop = "##end##";
+		$trig = "[^#]+";
+		for($i=1;$i<$maxpass+1;$i++) {
+			foreach ($this -> color_tags as $tag => $font)
+			{
+				if ($tag != $stop) {
+					if (preg_match("/(".$tag.$trig.$stop.")/i", $text, $matches, PREG_OFFSET_CAPTURE))
+					{
+						$prev = substr($text, 0, $matches[1][1]);
+						$repl = str_ireplace($tag, $font, $matches[1][0]);
+						$repl = preg_replace("/".$stop."/", "</font>", $repl, 1);
+						$post = substr($text, $matches[1][1] + strlen($matches[1][0]));
+						$text = $prev.$repl.$post;
+					}			
+				}
+			}
+			$trig = "(?:.*)";
+		}
+	$text = str_ireplace("##end##", "</font>", $text);
         return $text;
     }
 

--- a/Main/15_Colors.php
+++ b/Main/15_Colors.php
@@ -533,6 +533,10 @@ class Colors_Core extends BasePassiveModule
             }
         }
         $text = str_ireplace("##end##", "</font>", $text);
+	foreach ($this -> color_tags as $tag => $font)
+	{
+		$text = str_ireplace($tag, $font, $text);
+	}	    
         return $text;
     }
 

--- a/Modules/Ao/Items.php
+++ b/Modules/Ao/Items.php
@@ -42,7 +42,7 @@ class VhItems extends BaseActiveModule
     var $color_header = 'DFDF00';
     var $color_highlight = '97BE37';
     var $color_normal = 'CCF0AD';
-    var $server = 'http://cidb.xyphos.com/';
+    var $server = 'http://cidb.botsharp.net/';
     var $max = 50;
 
 

--- a/Sources/Bot.php
+++ b/Sources/Bot.php
@@ -317,20 +317,15 @@ class Bot
         $this->cron_activated = false;
         // Get dimension server
         switch ($this->dimension) {
-            case "4":
-                $dimension = "Testlive";
-                break;
-            case "1":
-                $dimension = "Rubi-Ka";
-                break;
-            case "2":
-                $dimension = "Rubi-Ka";
-                break;
-            case "3":
-                $dimension = "Rubi-Ka";
-                break;
-            case "5":
-                $dimension = "Rubi-Ka";
+			case "0":
+				$dimension = "Testlive";
+				break;
+			case "5";
+				$dimension = "Rubi-Ka";
+				break;
+			case "6";
+				$dimension = "Rubi-Ka-2019";
+				break;				
             Default:
                 $dimension = ucfirst(strtolower($this->dimension));
         }


### PR DESCRIPTION
In some specific cases typically like sending sole triggered words like colors (e.g. "pink" which can be used during a pandemonium raid) or sides (e.g. "omni" or "clan" which can be answered on specific questions) the resulting color parsing would become partially or totally broken. The proposed fix doesn't prevent all possible entries to break it but at least ensures the parser will correctly search for fully formatted expressions including font ending. This should cover most human natural use of the chat if not all.