### PR TITLE
[AOC] Fix multiple toon on the same account

### DIFF
--- a/Sources/AocLogin/CharacterServerConnection.php
+++ b/Sources/AocLogin/CharacterServerConnection.php
@@ -199,6 +199,8 @@ class CharacterServerConnection extends ServerConnection
                         $blocked = $stream->ReadUInt32();
                         $stream->ReadUInt32(); // ?? Offline levels
                         $stream->ReadString(); // ?? Blob MD5
+                        $stream->ReadUInt32(); // ??
+                        $stream->ReadUInt32(); // ??
 
                         $this->m_Parent->chars[] = array(
                             "id" => $characterID,


### PR DESCRIPTION
The parsing of AOC character data stream seems wrong.
It parses the first toon correctly (name, level, etc.) but all other toons are bugged. This is due to a character profile having 2 extra uint32 (or a problem with how to read that md5 blob, idk).

This PR simple skips two more ints and now all toons on the account can be used as bot.

btw, those two ints are FFFFFFF9 and 00000000 for me.